### PR TITLE
bug: fixing the import demo for kmeans cluster

### DIFF
--- a/src/lib/cluster/k_means.ts
+++ b/src/lib/cluster/k_means.ts
@@ -25,7 +25,7 @@ export interface KMeansOptions {
  * K-Means clustering
  *
  * @example
- * import { KMeans } from 'kalimdor/k_means';
+ * import { KMeans } from 'kalimdor/cluster';
  *
  * const kmean = new KMeans({ k: 2 });
  * const clusters = kmean.fit({ X: [[1, 2], [1, 4], [1, 0], [4, 2], [4, 4], [4, 0]] });


### PR DESCRIPTION
KMeans clustering example fix

```
improt kmeans from 'kalimdor/k_means`; // incorrect
```

to 

```
import { KMeans } from 'kalimdor/cluster';
```