### PR TITLE
Feature/normalize l1 and l2

### DIFF
--- a/src/lib/preprocessing/data.ts
+++ b/src/lib/preprocessing/data.ts
@@ -631,7 +631,7 @@ export class PolynomialFeatures {
 
 /**
  * Data normalization is a process of scaling dataset based on Vector Space Model, for example, L1 and L2.
- * By default, it will be using L1 normalization. At a higher level,
+ * By default, it will be using L2 normalization. At a higher level,
  * the chief difference between the L1 and the L2 terms is that the L2 term is proportional
  * to the square of the  β values, while the L1 norm is proportional the absolute value of the values in  β .
  *

--- a/src/lib/preprocessing/data.ts
+++ b/src/lib/preprocessing/data.ts
@@ -629,3 +629,72 @@ export class PolynomialFeatures {
   }
 }
 
+/**
+ * Data normalization is a process of scaling dataset based on Vector Space Model, for example, L1 and L2.
+ * By default, it will be using L1 normalization. At a higher level,
+ * the chief difference between the L1 and the L2 terms is that the L2 term is proportional
+ * to the square of the  β values, while the L1 norm is proportional the absolute value of the values in  β .
+ *
+ * @example
+ * import { normalize } from 'kalimdor/preprocess';
+ *
+ * const result = normalize({
+ *   X: [
+ *     [1, -1, 2],
+ *     [2, 0, 0],
+ *     [0, 1, -1],
+ *   ],
+ * });
+ * console.log(result);
+ * // [ [ 0.4082482904638631, -0.4082482904638631, 0.8164965809277261 ],
+ * // [ 1, 0, 0 ],
+ * // [ 0, 0.7071067811865475, -0.7071067811865475 ] ]
+ *
+ * @param X - The data to normalize
+ * @param norm - The norm to use to normalize each non zero sample; can be either 'l1' or 'l2'
+ * @return number[][]
+ */
+export function normalize({
+  X = null,
+  norm = 'l2',
+}: {
+  X: number[][],
+  norm?: string,
+} = {
+  X: null,
+  norm: 'l2',
+}): number[][] {
+
+  // Validation
+  if (!math.contrib.isMatrixOf(X, 'number')) {
+    throw new Error('The data input must be a matrix of numbers');
+  }
+
+  const normalizedMatrix = [];
+  for (let i = 0; i < X.length; i++) {
+    const row = X[i];
+
+    // Adding a placeholder array
+    normalizedMatrix.push([]);
+
+    // Getting the row's square root
+    let proportion: any = 0; // note: any because math.pow return MathType
+
+    // Normalization proportion value
+    if (norm === 'l1') {
+      proportion = row.reduce((accum: any, r) => accum + Math.abs(r), 0);
+    } else if (norm === 'l2') {
+      proportion = row.reduce((accum: any, r) => accum + math.pow(r, 2), 0);
+      proportion = Math.sqrt(proportion);
+    } else {
+      throw new Error(`${norm} is not a recognised normalization method`);
+    }
+
+    // Finally applying a cubic root to the total value
+    for (let k = 0; k < row.length; k++) {
+      const value = row[k] / proportion;
+      normalizedMatrix[i].push(value);
+    }
+  }
+  return normalizedMatrix;
+}

--- a/src/lib/preprocessing/data.ts
+++ b/src/lib/preprocessing/data.ts
@@ -630,9 +630,8 @@ export class PolynomialFeatures {
 }
 
 /**
- * Data normalization is a process of scaling dataset based on Vector Space Model, for example, L1 and L2.
- * By default, it will be using L2 normalization. At a higher level,
- * the chief difference between the L1 and the L2 terms is that the L2 term is proportional
+ * Data normalization is a process of scaling dataset based on Vector Space Model, and by default, it uses L2 normalization.
+ * At a higher level, the chief difference between the L1 and the L2 terms is that the L2 term is proportional
  * to the square of the  β values, while the L1 norm is proportional the absolute value of the values in  β .
  *
  * @example

--- a/src/lib/utils/validation.ts
+++ b/src/lib/utils/validation.ts
@@ -9,7 +9,7 @@ import * as _ from 'lodash';
  *   If the given arr is an array then the value is true else false
  * @param arr
  * @returns {any}
- * @ignore
+ * @ignoreCannot perform
  */
 export function checkArray(
   arr: any[]

--- a/test/preprocessing/data.test.ts
+++ b/test/preprocessing/data.test.ts
@@ -6,6 +6,7 @@ import {
   MinMaxScaler,
   OneHotEncoder,
   PolynomialFeatures,
+  normalize,
 } from '../../src/lib/preprocessing/data';
 
 describe('data:add_dummy_feature', () => {
@@ -189,5 +190,43 @@ describe('data:PolynomialFeatures', () => {
     expect(() => new PolynomialFeatures({ degree: null })).toThrow(expected);
     expect(() => new PolynomialFeatures({ degree: 'string' })).toThrow(expected);
     expect(() => new PolynomialFeatures({ degree: [] })).toThrow(expected);
+  });
+});
+
+describe('data:normalize', () => {
+  const X1 = [[1, -1, 2], [2, 0, 0], [0, 1, -1]];
+  it('should normalize X1 with l2 norm', () => {
+    const expected = [
+      [0.4082482904638631, -0.4082482904638631, 0.8164965809277261],
+      [1, 0, 0],
+      [0, 0.7071067811865475, -0.7071067811865475]
+    ];
+    const result = normalize({
+      X: X1,
+      norm: 'l2',
+    });
+    expect(result).toEqual(expected);
+  });
+  it('should normalize X1 with l1 norm', () => {
+    const expected = [
+      [ 0.25, -0.25,  0.5 ],
+      [ 1.  ,  0.  ,  0.  ],
+      [ 0.  ,  0.5 , -0.5 ],
+    ];
+    const result = normalize({
+      X: X1,
+      norm: 'l1',
+    });
+    expect(result).toEqual(expected);
+  });
+  it('should throw an error if unrecognised norm is passed in', () => {
+    const expected = 'test is not a recognised normalization method';
+    expect(() => normalize({ X: X1, norm: 'test' })).toThrow(expected);
+  });
+  it('should throw an error if the input is invalid', () => {
+    const nullException = 'Cannot perform isMatrixOf number unless the data is matrix';
+    expect(() => normalize({ X: null, norm: 'l1' })).toThrow(nullException);
+    expect(() => normalize({ X: [], norm: 'l1' })).toThrow(nullException);
+    expect(() => normalize({ X: 'aisjd', norm: 'l1' })).toThrow(nullException);
   });
 });


### PR DESCRIPTION
Adding `preprocessing/normalize` into the APIs. 

**Context:**
Data normalization is a process of scaling dataset based on Vector Space Model, for example, L1 and L2. By default, it will be using L1 normalization. At a higher level, the chief difference between the L1 and the L2 terms is that the L2 term is proportional to the square of the  β values, while the L1 norm is proportional the absolute value of the values in  β .

**Notes**

Although the branch name suggests only `l2` is implemented, the PR contains both `l1` and `l2`.

**Completed**

- Implementation
- Tests
- Documentation